### PR TITLE
fix: switch balance when switching tokens

### DIFF
--- a/src/components/SwapComponent/index.js
+++ b/src/components/SwapComponent/index.js
@@ -267,8 +267,17 @@ const SwapComponent = props => {
   // connect to page model, reflect changes of pair ratio in this component
   useEffect(() => {
     const { swap: { token0: modelToken0, token1: modelToken1 } } = props;
+    
     setToken0(modelToken0);
     setToken1(modelToken1);
+
+    console.log(">> old new token 0/1 compare", token0 == modelToken1, token1 == modelToken0)
+    if (token0 == modelToken1 && token1 == modelToken0) {
+      const newToken0Balance = token1Balance;
+      const newToken1Balance = token0Balance;
+      setToken0Balance(newToken0Balance);
+      setToken1Balance(newToken1Balance);
+    }
   }, [props.swap]);
 
   useEffect(() => {


### PR DESCRIPTION
在`src/pages/swap/model/swap`里有token0，token1，他们保存着swap component最新的token0，token1。在commit的281行里我获取Swap的[页面model](https://v2.umijs.org/zh/guide/with-dva.html#model-%E6%B3%A8%E5%86%8C)数据，并且判断是否需要兑换token的余额。